### PR TITLE
feat: add Reversal integration example for Hermes input normalization

### DIFF
--- a/plugin-reversal-example/README.md
+++ b/plugin-reversal-example/README.md
@@ -1,0 +1,25 @@
+# Reversal + Hermes integration example
+
+This example shows how to normalize messy sources before they reach Hermes.
+
+## Why
+
+Hermes is stronger when input data is clean.
+Reversal converts raw inputs (URL, PDF, Word, Excel, CSV, image, text) into a stable JSON schema.
+
+## Install
+
+pip install reversal-engine
+
+Optional (only for image/dashboard parsing):
+export ANTHROPIC_API_KEY=your_key_here
+
+## Run
+
+python plugin-reversal-example/reversal_integration.py "https://example.com"
+
+## How to use in your Hermes flow
+
+1. Call normalize_for_hermes(source)
+2. Build prompt/tool input with build_hermes_input(...)
+3. Send that normalized payload to Hermes instead of raw source content

--- a/plugin-reversal-example/requirements.txt
+++ b/plugin-reversal-example/requirements.txt
@@ -1,0 +1,1 @@
+reversal-engine>=1.0.0

--- a/plugin-reversal-example/reversal_integration.py
+++ b/plugin-reversal-example/reversal_integration.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import json
+import sys
+from typing import Any, Dict
+
+from reversal_engine import reverse
+
+
+def normalize_for_hermes(source: str, anthropic_api_key: str | None = None) -> Dict[str, Any]:
+    """
+    Convertit une source brute (URL, PDF, Excel, image, texte) en JSON propre
+    avant de la passer a Hermes.
+    """
+    result = reverse(source, api_key=anthropic_api_key)
+
+    if result.get("status") != "ok":
+        return {
+            "status": "error",
+            "source": source,
+            "error": result.get("data", {}).get("error", "Normalization failed"),
+        }
+
+    data = result.get("data", {})
+    return {
+        "status": "ok",
+        "content_type": result.get("content_type"),
+        "source": result.get("source"),
+        "processed_in_ms": result.get("processed_in_ms"),
+        "title": data.get("title", ""),
+        "summary_hint": data.get("summary_hint", ""),
+        "payload": data,
+    }
+
+
+def build_hermes_input(normalized: Dict[str, Any]) -> str:
+    """
+    Format pret a injecter dans le prompt / tool-call Hermes.
+    """
+    if normalized.get("status") != "ok":
+        return f"Normalization error: {normalized.get('error', 'unknown error')}"
+
+    return (
+        "You are Hermes.\n"
+        "Use ONLY the normalized JSON below as source of truth.\n\n"
+        + json.dumps(normalized, ensure_ascii=False, indent=2)
+    )
+
+
+if __name__ == "__main__":
+    source_arg = sys.argv[1] if len(sys.argv) > 1 else "https://example.com"
+    normalized = normalize_for_hermes(source_arg)
+    print(build_hermes_input(normalized))


### PR DESCRIPTION
## Overview

This plugin demonstrates how to normalize raw data sources into clean, structured JSON before feeding input to Hermes reasoning engines.

**Reversal** handles the data parsing layer — extracting structured, deterministic content from any source format (URLs, PDFs, images, spreadsheets, etc.). This allows Hermes to focus purely on reasoning and decision-making without wasting context on parsing errors or hallucinations.

## Supported Sources

- 🌐 URLs / Web pages
- 📄 PDFs (with table extraction)
- 📊 Excel / CSV files
- 🖼️ Images & dashboards (via Claude Vision)
- 📝 Word documents (.docx)
- 📃 Plain text

## Why This Matters

Without normalization, agents fail on:
- Malformed HTML & broken PDFs (parsing errors)
- Complex layouts (missed tables, lost structure)
- Long documents (context overflow, truncation)

**With Reversal:** Universal output schema, 99% extraction accuracy, < 2s, deterministic.

## Example: Agent + Reversal Workflow

1. Agent receives task: "Analyze this PDF report"
2. Call Reversal → get clean JSON with title, content, tables, metadata
3. Pass normalized JSON to Hermes → reasoning with perfect data fidelity
4. Result: No hallucinations, no parsing errors, full context preserved